### PR TITLE
Alignment and spacing in topic list

### DIFF
--- a/src/Modules/Topics/TopicList/Components/TopicList.css
+++ b/src/Modules/Topics/TopicList/Components/TopicList.css
@@ -1,0 +1,4 @@
+.pf-c-toolbar-item--search,
+.pf-c-toolbar-item--search .pf-c-search-input {
+  flex: 0 1 20em;
+}

--- a/src/Modules/Topics/TopicList/Components/TopicsList.tsx
+++ b/src/Modules/Topics/TopicList/Components/TopicsList.tsx
@@ -4,6 +4,7 @@ import {
   Card,
   Divider,
   Pagination,
+  PaginationVariant,
   Title,
   Toolbar,
   ToolbarContent,
@@ -14,6 +15,7 @@ import {
   TableBody,
   TableHeader,
   TableVariant,
+  sortable,
 } from '@patternfly/react-table';
 import { useTimeout } from '../../../../Hooks/useTimeOut';
 import { SearchTopics } from './SearchTopics';
@@ -25,6 +27,8 @@ import { useHistory } from 'react-router';
 import { ConfigContext } from '../../../../Contexts';
 import { TopicsList } from '../../../../OpenApi';
 import { Loading } from '../../../../Components/Loading/Loading';
+
+import './TopicList.css';
 
 export interface ITopic {
   name: string;
@@ -86,8 +90,8 @@ export const TopicsListComponent: React.FunctionComponent<ITopicList> = ({
 
   const tableColumns = [
     { title: 'Name' },
-    { title: 'Replicas' },
-    { title: 'Partitions' },
+    { title: 'Replicas', transforms: [sortable] },
+    { title: 'Partitions', transforms: [sortable] },
   ];
   const rowData =
     filteredTopics?.items?.map((topic) => [
@@ -95,6 +99,7 @@ export const TopicsListComponent: React.FunctionComponent<ITopicList> = ({
         title: (
           <Button
             variant='link'
+            isInline
             onClick={() =>
               onTopicClick((topic && topic.name && topic.name.toString()) || '')
             }
@@ -173,7 +178,7 @@ export const TopicsListComponent: React.FunctionComponent<ITopicList> = ({
         <Card>
           <Toolbar>
             <ToolbarContent>
-              <ToolbarItem>
+              <ToolbarItem className='pf-c-toolbar-item--search'>
                 <SearchTopics
                   onClear={onClear}
                   search={search}
@@ -203,7 +208,6 @@ export const TopicsListComponent: React.FunctionComponent<ITopicList> = ({
               </ToolbarItem>
             </ToolbarContent>
           </Toolbar>
-          <Divider />
 
           <Table
             aria-label='Compact Table'
@@ -221,6 +225,7 @@ export const TopicsListComponent: React.FunctionComponent<ITopicList> = ({
           </Table>
         </Card>
       )}
+      <Divider />
       {rowData.length < 1 && search.length > 1 && <EmptySearch />}
       {rowData.length > 1 && (
         <Pagination
@@ -231,6 +236,7 @@ export const TopicsListComponent: React.FunctionComponent<ITopicList> = ({
           widgetId='topic-list-pagination-bottom'
           onPerPageSelect={onPerPageSelect}
           offset={0}
+          variant={PaginationVariant.bottom}
         />
       )}
     </>


### PR DESCRIPTION
Signed-off-by: Sarah Rambacher <srambach@redhat.com>

Fixes alignment and spacing in the topics list. Search field should not bump the Create Topic button over now. Horizontal line removed from between toolbar and list, and is added at the bottom.
Sorting is added to the columns.
