### PR TITLE
Verify delete action before deleting

### DIFF
--- a/src/Modules/Topics/TopicList/Components/DeleteTopicsModal.tsx
+++ b/src/Modules/Topics/TopicList/Components/DeleteTopicsModal.tsx
@@ -49,7 +49,7 @@ export const DeleteTopics: React.FunctionComponent<IDeleteTopics> = ({
     <Modal
       variant={ModalVariant.small}
       isOpen={deleteModal}
-      aria-label='Modal warning'
+      aria-label='Delete topic?'
       title=' Delete topic  ?'
       titleIconVariant='warning'
       showClose={true}


### PR DESCRIPTION
This PR adds a verification step before deleting, where a user has to type 'delete' to confirm that the delete action is intended.

![image](https://user-images.githubusercontent.com/11834809/111993994-44e42380-8b3d-11eb-93a8-337ea554deaf.png)

![image](https://user-images.githubusercontent.com/11834809/111994109-60e7c500-8b3d-11eb-8065-79ce40c7a774.png)
