### PR TITLE
refactor: filter consumer groups for a topic

### DIFF
--- a/mock-server/src/strimzi-api-handlers.js
+++ b/mock-server/src/strimzi-api-handlers.js
@@ -3,12 +3,27 @@ var consumerGroups = require('../_data_/consumer-groups.json');
 
 module.exports = {
   getConsumerGroupList: async (c, req, res) => {
+
+    let consumerGroupList = consumerGroups;
+    let count = consumerGroups?.length;
+
+    const filterConsumerGroups = (topicName) => {
+      return consumerGroupList.filter(consumerGroup => {
+        return consumerGroup.consumers.some(consumer => consumer.topic === topicName)
+      });
+    }
+
+    if(consumerGroups && req?.query?.topic && req?.query?.topic?.trim() !== "") {
+      consumerGroupList = filterConsumerGroups(req?.query?.topic);
+      count = consumerGroupList.length;
+    }
+
     return res.status(200).json({
       limit: parseInt(req.query.limit, 10) || 100,
       offset: 0,
-      count: consumerGroups.length,
-      items: consumerGroups,
-    });
+      count,
+      items: consumerGroupList
+    })
   },
   getConsumerGroupById: async (c, req, res) => {
     const group = getConsumerGroup(c.request.params.consumerGroupId);


### PR DESCRIPTION
`getConsumerGroupList` now filters consumer groups with respect to topic.

Passing a topic name as query parameter will return consumer groups for that particular topic.

After starting the mock server, make a GET request to `http://localhost:8000/api/managed-services-strimzi-ui/v1/api/consumer-groups?topic=topic-3`