### PR TITLE
Remove extra divider in creation wizard

### DIFF
--- a/src/Modules/Topics/CreateTopic/Components/CreateTopicHead.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/CreateTopicHead.tsx
@@ -3,7 +3,6 @@ import {
   PageSectionVariants,
   Title,
   Switch,
-  Divider,
   Breadcrumb,
   BreadcrumbItem,
 } from '@patternfly/react-core';
@@ -50,7 +49,6 @@ export const CreateTopichead: React.FC<ICreateTopicProps> = ({
           className='create-topic-wizard'
         />
       </PageSection>
-      <Divider />
     </>
   );
 };

--- a/src/Modules/Topics/CreateTopic/Components/CreateTopicWizard.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/CreateTopicWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
 import {
   AlertVariant,
+  Divider,
   PageSection,
   PageSectionTypes,
   PageSectionVariants,
@@ -62,7 +63,7 @@ export const CreateTopicWizard: React.FC<ICreateTopicWizard> = ({
     'retention.ms.unit': 'days',
     'retention.bytes': '-1',
     'retention.bytes.unit': 'bytes',
-    'log.cleanup.policy': 'delete'
+    'log.cleanup.policy': 'delete',
   });
 
   const [currentPeriod, setCurrentPeriod] = React.useState<string | number>(
@@ -177,6 +178,7 @@ export const CreateTopicWizard: React.FC<ICreateTopicWizard> = ({
     <>
       {isSwitchChecked ? (
         <>
+          <Divider />
           <PageSection variant={PageSectionVariants.light}>
             <TopicAdvanceConfig
               isCreate={true}


### PR DESCRIPTION
There was an extra divider in the topic creation wizard making it thicker than it should be. The divider was moved out of the header to where the advanced options are shown.