### PR TITLE
fix: change key name for error response

### DIFF
--- a/mock-server/src/strimzi-api-handlers.js
+++ b/mock-server/src/strimzi-api-handlers.js
@@ -76,13 +76,13 @@ module.exports = {
     const topicBody = c.request.body;
 
     if (!topicBody) {
-      return res.status(400).json({ err: 'Bad request' });
+      return res.status(400).json({ error: 'Bad request' });
     }
 
     let topic = getTopic(topicBody.name);
 
     if (topic) {
-      return res.status(409).json({ err: 'topic exists' });
+      return res.status(409).json({ error: 'topic exists' });
     }
 
     topic = {
@@ -122,7 +122,7 @@ module.exports = {
   getTopic: async (c, req, res) => {
     const topic = getTopic(c.request.params.topicName);
     if (!topic) {
-      return res.status(404).json({ err: 'not found' });
+      return res.status(404).json({ error: 'not found' });
     }
     return res.status(200).json(topic);
   },
@@ -132,7 +132,7 @@ module.exports = {
 
     const topic = getTopic(topicName);
     if (!topic) {
-      return res.status(404).json({ err: 'not found' });
+      return res.status(404).json({ error: 'not found' });
     }
     topics = topics.filter((t) => t.name !== topicName);
 
@@ -144,7 +144,7 @@ module.exports = {
     const topicBody = c.request.body;
 
     if (!topicBody) {
-      return res.status(400).json({ err: 'Bad request' });
+      return res.status(400).json({ error: 'Bad request' });
     }
 
     const topic = getTopic(topicName);
@@ -157,7 +157,7 @@ module.exports = {
     }
 
     if (!topic) {
-      return res.status(404).json({ err: 'not found' });
+      return res.status(404).json({ error: 'not found' });
     }
 
     if (

--- a/src/Modules/Topics/CreateTopic/Components/CreateTopicWizard.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/CreateTopicWizard.tsx
@@ -114,7 +114,7 @@ export const CreateTopicWizard: React.FC<ICreateTopicWizard> = ({
         closeWizard();
       })
       .catch((err) => {
-        addAlert(err.response.data.err, AlertVariant.danger);
+        addAlert(err.response.data.error, AlertVariant.danger);
         closeWizard();
       });
   };

--- a/src/Modules/Topics/TopicList/Components/DeleteTopicsModal.tsx
+++ b/src/Modules/Topics/TopicList/Components/DeleteTopicsModal.tsx
@@ -33,7 +33,7 @@ export const DeleteTopics: React.FunctionComponent<IDeleteTopics> = ({
       topicName && (await deleteTopic(topicName, config));
       addAlert(`Successfully deleted topic ${topicName}`, AlertVariant.success);
     } catch (err) {
-      addAlert(err.response.data.err, AlertVariant.danger);
+      addAlert(err.response.data.error, AlertVariant.danger);
     }
     onDeleteTopic();
     setDeleteModal(false);


### PR DESCRIPTION
Staging uses `error` key for error message whereas mock-server used `err` which resulted into alerts with empty messages.