### PR TITLE
Fix the jump link navigation

### DIFF
--- a/src/Modules/Topics/CreateTopic/Components/TopicAdvanceConfig.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/TopicAdvanceConfig.tsx
@@ -142,7 +142,7 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
           <JumpLinks
             isVertical
             label='JUMP TO SECTION'
-            scrollableSelector='#main-container'
+            scrollableSelector='.pf-c-page__main:first-of-type'
             style={{ position: 'sticky' }}
             offset={-164} // for header
             expandable={{ default: 'expandable', md: 'nonExpandable' }}

--- a/src/Modules/Topics/TopicDetails/Components/TopicDetailView.tsx
+++ b/src/Modules/Topics/TopicDetails/Components/TopicDetailView.tsx
@@ -40,37 +40,38 @@ export const TopicDetailView: React.FunctionComponent<TopicViewDetailProps> = ({
     <PageSection className='kafka-ui--page__main-section--adjust-padding'>
       <Sidebar hasGutter>
         <SidebarPanel variant='sticky'>
-          <JumpLinks
-            isVertical
-            label='JUMP TO SECTION'
-            scrollableSelector='#topic-detail-view'
-            style={{ position: 'absolute' }}
+        <JumpLinks
+          isVertical
+          label='JUMP TO SECTION'
+          scrollableSelector='.pf-c-page__main:first-of-type'
+          offset={-164} // for header
+          style={{ position: 'sticky' }}
           >
-            <JumpLinksItem key={0} href='#core-configuration'>
-              Core configuration
-            </JumpLinksItem>
-            <JumpLinksItem key={1} href='#messages'>
-              Messages
-            </JumpLinksItem>
-            <JumpLinksItem key={2} href='#log'>
-              Log
-            </JumpLinksItem>
-            <JumpLinksItem key={3} href='#replication'>
-              Replication
-            </JumpLinksItem>
-            <JumpLinksItem key={4} href='#cleanup'>
-              Cleanup
-            </JumpLinksItem>
-            <JumpLinksItem key={5} href='#index'>
-              Index
-            </JumpLinksItem>
-            <JumpLinksItem key={6} href='#flush'>
-              Flush
-            </JumpLinksItem>
-            <JumpLinksItem key={7} href='#delete'>
-              Delete
-            </JumpLinksItem>
-          </JumpLinks>
+          <JumpLinksItem key={0} href='#core-configuration'>
+            Core configuration
+          </JumpLinksItem>
+          <JumpLinksItem key={1} href='#messages'>
+            Messages
+          </JumpLinksItem>
+          <JumpLinksItem key={2} href='#log'>
+            Log
+          </JumpLinksItem>
+          <JumpLinksItem key={3} href='#replication'>
+            Replication
+          </JumpLinksItem>
+          <JumpLinksItem key={4} href='#cleanup'>
+            Cleanup
+          </JumpLinksItem>
+          <JumpLinksItem key={5} href='#index'>
+            Index
+          </JumpLinksItem>
+          <JumpLinksItem key={6} href='#flush'>
+            Flush
+          </JumpLinksItem>
+          <JumpLinksItem key={7} href='#delete'>
+            Delete
+          </JumpLinksItem>
+        </JumpLinks>
         </SidebarPanel>
         <SidebarContent>
           <PageGroup hasOverflowScroll id='topic-detail-view'>


### PR DESCRIPTION
This fixes the jump link navigation on the create topic/advanced options page as well as the View Details and Update topic pages. The scrollableSelector needed to be updated to be the element that gets the scroll, which is the first main page section.