### PR TITLE
Calculate active members of a consumer group

### DIFF
--- a/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupDetail.tsx
+++ b/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupDetail.tsx
@@ -77,7 +77,10 @@ export const ConsumerGroupDetail: React.FunctionComponent<IConsumerGroupDetailPr
                 Active members
               </Text>
               <Text component={TextVariants.h2}>
-                {consumerDetail && consumerDetail.consumers.length}
+                {consumerDetail &&
+                  consumerDetail.consumers.reduce(function (prev, cur) {
+                    return prev + cur.partition != -1 ? prev + 1 : 0;
+                  }, 0)}
               </Text>
             </FlexItem>
             <FlexItem>

--- a/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupList.tsx
+++ b/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupList.tsx
@@ -160,7 +160,9 @@ export const ConsumerGroupsList: React.FunctionComponent<IConsumerGroupsList> = 
         ),
       },
 
-      consumer.consumers?.length,
+      consumer.consumers.reduce(function (prev, cur) {
+        return prev + cur.partition != -1 ? prev + 1 : 0;
+      }, 0),
       consumer.consumers.reduce(function (prev, cur) {
         return prev + cur.lag > 0 ? prev + 1 : 0;
       }, 0),


### PR DESCRIPTION
This PR finds the number of active members from a pool of consumers of a consumer group:
Formula used: No of consumers with partitions not equal to -1