### PR TITLE
Add id for new page main to jumplinks

### DIFF
--- a/src/Modules/Topics/CreateTopic/Components/TopicAdvanceConfig.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/TopicAdvanceConfig.tsx
@@ -385,7 +385,7 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
           <JumpLinks
             isVertical
             label='JUMP TO SECTION'
-            scrollableSelector='.pf-c-page__main:first-of-type'
+            scrollableSelector='#scrollablePageMain'
             style={{ position: 'sticky' }}
             offset={-164} // for header
             expandable={{ default: 'expandable', md: 'nonExpandable' }}

--- a/src/Modules/Topics/TopicDetails/Components/TopicDetailView.tsx
+++ b/src/Modules/Topics/TopicDetails/Components/TopicDetailView.tsx
@@ -43,7 +43,7 @@ export const TopicDetailView: React.FunctionComponent<TopicViewDetailProps> = ({
           <JumpLinks
             isVertical
             label='JUMP TO SECTION'
-            scrollableSelector='.pf-c-page__main:first-of-type'
+            scrollableSelector='#scrollablePageMain'
             offset={-164} // for header
             style={{ position: 'sticky' }}
           >


### PR DESCRIPTION
When a new page main was added in application-services-ui DevelopmentPreview.tsx, the scrollable selector changed and jumplinks broke. This points to a new id on that element and fixes the jumplinks.