### PR TITLE
fix min value

### DIFF
--- a/src/Modules/Topics/CreateTopic/Components/StepPartitions.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/StepPartitions.tsx
@@ -18,6 +18,7 @@ export const StepPartitions: React.FC<IStepPartitions> = ({
   partitionTouchspinValue,
   setPartitionTouchspinValue,
 }) => {
+  const minValue = 1;
   const handleOnPlus = () => {
     setPartitionTouchspinValue(partitionTouchspinValue + 1);
   };
@@ -25,7 +26,11 @@ export const StepPartitions: React.FC<IStepPartitions> = ({
     setPartitionTouchspinValue(partitionTouchspinValue - 1);
   };
   const handlePartitionTouchspinChange = (event) => {
-    setPartitionTouchspinValue(Number(event.target.value));
+    let num = Number(event.target.value);
+    if (num < minValue) {
+      num = minValue;
+    }
+    setPartitionTouchspinValue(num);
   };
 
   return (
@@ -54,7 +59,7 @@ export const StepPartitions: React.FC<IStepPartitions> = ({
             inputName='input'
             onChange={handlePartitionTouchspinChange}
             widthChars={20}
-            min={1}
+            min={minValue}
           />
         </FormGroup>
       </Form>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MGDSTRM-3093
To summarize:
Min value for partitions is 1. However, a user can manually enter 0, at which point the decrement button becomes enabled and the user could use that to get a negative value as well.
Fix is to check on change if the value is less than 1, and if so set it to 1.

@pmuir @MikeEdgar 