### PR TITLE
fix: reduce callbacks for consumer groups properties

### DIFF
--- a/mock-server/_data_/consumer-groups.json
+++ b/mock-server/_data_/consumer-groups.json
@@ -44,5 +44,83 @@
         "logEndOffset": 3
       }
     ]
+  },
+  {
+    "groupId": "consumer_group_3",
+    "consumers": [
+      {
+        "groupId": "consumer_group_3",
+        "topic": "topic-2",
+        "partition": 10,
+        "memberId": "consumer_group_3_member2",
+        "offset": 5,
+        "lag": 0,
+        "logEndOffset": 5
+      },
+      {
+        "groupId": "consumer_group_3",
+        "topic": "topic-1",
+        "partition": -1,
+        "memberId": "consumer_group_3_member2",
+        "offset": 3,
+        "lag": 10,
+        "logEndOffset": 3
+      }
+    ]
+  },
+  {
+    "groupId": "consumer_group_4",
+    "consumers": [
+      {
+        "groupId": "consumer_group_4",
+        "topic": "topic-2",
+        "partition": -1,
+        "memberId": "consumer_group_4_member2",
+        "offset": 5,
+        "lag": 0,
+        "logEndOffset": 5
+      },
+      {
+        "groupId": "consumer_group_4",
+        "topic": "topic-1",
+        "partition": -1,
+        "memberId": "consumer_group_4_member2",
+        "offset": 3,
+        "lag": 20,
+        "logEndOffset": 3
+      }
+    ]
+  },
+  {
+    "groupId": "consumer_group_5",
+    "consumers": [
+      {
+        "groupId": "consumer_group_5",
+        "topic": "topic-2",
+        "partition": -1,
+        "memberId": "consumer_group_5_member_1",
+        "offset": 5,
+        "lag": 10,
+        "logEndOffset": 5
+      },
+      {
+        "groupId": "consumer_group_5",
+        "topic": "topic-2",
+        "partition": 0,
+        "memberId": "consumer_group_5_member_2",
+        "offset": 5,
+        "lag": 0,
+        "logEndOffset": 5
+      },
+      {
+        "groupId": "consumer_group_5",
+        "topic": "topic-1",
+        "partition": -1,
+        "memberId": "consumer_group_5_member_3",
+        "offset": 3,
+        "lag": 100,
+        "logEndOffset": 3
+      }
+    ]
   }
 ]

--- a/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupDetail.tsx
+++ b/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupDetail.tsx
@@ -79,7 +79,7 @@ export const ConsumerGroupDetail: React.FunctionComponent<IConsumerGroupDetailPr
               <Text component={TextVariants.h2}>
                 {consumerDetail &&
                   consumerDetail.consumers.reduce(function (prev, cur) {
-                    return prev + cur.partition != -1 ? prev + 1 : 0;
+                    return prev + (cur.partition != -1 ? 1 : 0);
                   }, 0)}
               </Text>
             </FlexItem>
@@ -88,7 +88,7 @@ export const ConsumerGroupDetail: React.FunctionComponent<IConsumerGroupDetailPr
               <Text component={TextVariants.h2}>
                 {consumerDetail &&
                   consumerDetail.consumers.reduce(function (prev, cur) {
-                    return prev + cur.lag > 0 ? prev + 1 : 0;
+                    return prev + (cur.lag > 0 ? 1 : 0);
                   }, 0)}
               </Text>
             </FlexItem>

--- a/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupList.tsx
+++ b/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupList.tsx
@@ -203,10 +203,10 @@ export const ConsumerGroupsList: React.FunctionComponent<IConsumerGroupsList> = 
       },
 
       consumer.consumers.reduce(function (prev, cur) {
-        return prev + cur.partition != -1 ? prev + 1 : 0;
+        return prev + (cur.partition != -1 ? 1 : 0);
       }, 0),
       consumer.consumers.reduce(function (prev, cur) {
-        return prev + cur.lag > 0 ? prev + 1 : 0;
+        return prev + (cur.lag > 0 ? 1 : 0);
       }, 0),
     ]) || [];
 


### PR DESCRIPTION
Display correct values for `Active members` and `Partitions with lag` for consumer groups.

![Screenshot from 2021-05-10 20-46-31](https://user-images.githubusercontent.com/23582438/117683156-68d4f480-b1d1-11eb-9db7-1816fd125281.png)

Cc: @suyash-naithani 