### PR TITLE
Clean up empty states

### DIFF
--- a/src/Modules/ConsumerGroups/ConsumerGroupList/Components/EmptyConsumers.tsx
+++ b/src/Modules/ConsumerGroups/ConsumerGroupList/Components/EmptyConsumers.tsx
@@ -5,17 +5,20 @@ import {
   EmptyStateVariant,
   EmptyStateIcon,
   EmptyStateBody,
+  Bullseye,
 } from '@patternfly/react-core';
 import CubesIcon from '@patternfly/react-icons/dist/js/icons/cubes-icon';
 
 export const EmptyConsumers: React.FunctionComponent = () => {
   return (
-    <EmptyState variant={EmptyStateVariant.xl}>
-      <EmptyStateIcon icon={CubesIcon} />
-      <Title headingLevel='h5' size='4xl'>
-        No Consumer Groups Found
-      </Title>
-      <EmptyStateBody>You have No Consumer Groups</EmptyStateBody>
-    </EmptyState>
+    <Bullseye>
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={CubesIcon} />
+        <Title headingLevel="h4" size="lg">
+          No consumer groups yet
+        </Title>
+        <EmptyStateBody>When configuring an application client to access Kafka, assign a group ID to associate the consumer with a consumer group.</EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
   );
 };

--- a/src/Modules/Topics/TopicList/Components/EmptySearch.tsx
+++ b/src/Modules/Topics/TopicList/Components/EmptySearch.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Bullseye,
   EmptyState,
   EmptyStateIcon,
   EmptyStateBody,
@@ -9,15 +10,17 @@ import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 
 export const EmptySearch: React.FunctionComponent = () => {
   return (
-    <EmptyState>
-      <EmptyStateIcon icon={SearchIcon} />
-      <Title headingLevel='h5' size='lg'>
-        No results found
-      </Title>
-      <EmptyStateBody>
-        No result match the filter criteria. Remove filter or clear all filters
-        to show results
-      </EmptyStateBody>
-    </EmptyState>
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon icon={SearchIcon} />
+        <Title headingLevel='h4' size='lg'>
+          No results found
+        </Title>
+        <EmptyStateBody>
+          No result match the filter criteria. Remove filter or clear all filters
+          to show results.
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
   );
 };

--- a/src/Modules/Topics/TopicList/Components/EmptyTopics.tsx
+++ b/src/Modules/Topics/TopicList/Components/EmptyTopics.tsx
@@ -20,11 +20,11 @@ export const EmptyTopics: React.FunctionComponent<IEmptyTopic> = ({
     <Bullseye>
       <EmptyState>
         <EmptyStateIcon icon={PlusIcon} />
-        <Title headingLevel='h5' size='lg'>
+        <Title headingLevel='h4' size='lg'>
           You don&apos;t have any topics yet
         </Title>
         <EmptyStateBody>
-          Create a topic by clicking the button below to get started
+          Create a topic by clicking the button below to get started.
         </EmptyStateBody>
         <Button
           variant='primary'


### PR DESCRIPTION
This moves empty states into a Bullseye to center, adjusts the size of text, and modifies some wording.

![image](https://user-images.githubusercontent.com/19825616/118275722-cba9e280-b494-11eb-96a7-6c76b98234b8.png)

![image](https://user-images.githubusercontent.com/19825616/118275742-d1072d00-b494-11eb-9651-d1194c1ba235.png)

![image](https://user-images.githubusercontent.com/19825616/118275753-d5cbe100-b494-11eb-9327-11f7fc23e43f.png)

@dlabaj @jgiardino 