### PR TITLE
Add server side filtering for topics list and topic validation in basic and advanced flow

### DIFF
--- a/src/Components/FormGroupWithPopover/FormGroupWithPopover.tsx
+++ b/src/Components/FormGroupWithPopover/FormGroupWithPopover.tsx
@@ -12,6 +12,7 @@ interface IFormGroupWithPopoverProps {
   validated?: 'default' | 'error' | 'success' | 'warning' | undefined;
   helperText?: string;
   helperTextInvalid?: string;
+  isRequired?: boolean;
 }
 
 export const FormGroupWithPopover: React.FC<IFormGroupWithPopoverProps> = ({
@@ -24,6 +25,7 @@ export const FormGroupWithPopover: React.FC<IFormGroupWithPopoverProps> = ({
   validated,
   helperText,
   helperTextInvalid,
+  isRequired,
 }) => {
   const preventButtonSubmit = (event) => event.preventDefault();
 
@@ -34,6 +36,7 @@ export const FormGroupWithPopover: React.FC<IFormGroupWithPopoverProps> = ({
       validated={validated}
       helperText={helperText}
       helperTextInvalid={helperTextInvalid}
+      isRequired={isRequired}
       labelIcon={
         <Popover
           headerContent={<div>{labelHead}</div>}

--- a/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupList.tsx
+++ b/src/Modules/ConsumerGroups/ConsumerGroupList/Components/ConsumerGroupList.tsx
@@ -221,7 +221,9 @@ export const ConsumerGroupsList: React.FunctionComponent<IConsumerGroupsList> = 
 
   return (
     <>
-      {rowData.length < 1 && search.length < 1 ? (
+      {consumerGroups?.count &&
+      consumerGroups.count < 1 &&
+      search.length < 1 ? (
         <EmptyState
           emptyStateProps={{
             variant: MASEmptyStateVariant.NoConsumerGroups,

--- a/src/Modules/Topics/CreateTopic/Components/StepTopicName.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/StepTopicName.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Form,
   FormGroup,
@@ -15,6 +15,8 @@ export interface IStepTopicName {
   setTopicNameInput: (value: string) => void;
   topicNameValidated: 'error' | 'default';
   setTopicNameValidated: (value: 'error' | 'default') => void;
+  invalidText: string;
+  setInvalidText: (value: string) => void;
 }
 
 export const StepTopicName: React.FC<IStepTopicName> = ({
@@ -22,24 +24,19 @@ export const StepTopicName: React.FC<IStepTopicName> = ({
   setTopicNameInput,
   topicNameValidated,
   setTopicNameValidated,
+  invalidText,
+  setInvalidText,
 }) => {
-  const [invalidText, setInvalidText] = useState('This is a required field');
-
   const { t } = useTranslation();
 
   const validationCheck = (topicNameInput) => {
     const regexpInvalid = new RegExp('^[0-9A-Za-z_-]+$');
     if (topicNameInput.length && !regexpInvalid.test(topicNameInput)) {
-      setInvalidText(
-        'Invalid input. Only letters (Aa-Zz) , numbers " _ " and " - " are accepted.'
-      );
-      setTopicNameValidated('error');
-    } else if (topicNameInput.length < 1) {
-      setInvalidText('This is a required field');
+      setInvalidText(t('topic.topic_name_helper_text'));
       setTopicNameValidated('error');
     } else if (topicNameInput.length > 249) {
       setTopicNameValidated('error');
-      setInvalidText('Topic name cannot exceed 249 characters');
+      setInvalidText(t('topic.cannot_exceed_characters'));
     } else setTopicNameValidated('default');
   };
 

--- a/src/Modules/Topics/CreateTopic/Components/TopicAdvanceConfig.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/TopicAdvanceConfig.tsx
@@ -67,17 +67,18 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
   topicData,
   setTopicData,
 }) => {
+  const [topicValidated, setTopicValidated] = useState<'error' | 'default'>(
+    'default'
+  );
+  const [invalidText, setInvalidText] = useState('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [partitionsValidated, setPartitionsValidated] = useState<
     'warning' | 'default'
   >('default');
   const [warning, setWarning] = useState<boolean>(false);
   const [initialPartition, setInitialPartition] = useState<number | undefined>(
-    0
+    Number(topicData.numPartitions)
   );
-  const [topicValidated, setTopicValidated] = useState<'error' | 'default'>(
-    'default'
-  );
-  const [invalidText, setInvalidText] = useState('This is a required field');
   const [isWarningOpen, setIsWarningOpen] = useState<boolean>(false);
 
   const { t } = useTranslation();
@@ -129,21 +130,31 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
 
   const config = useContext(ConfigContext);
   const fetchTopic = async (topicName) => {
-    const topicRes = await getTopic(topicName, config);
-
-    const configEntries: any = {};
-    topicRes.config?.forEach((configItem) => {
-      configEntries[configItem.key || ''] = configItem.value || '';
-    });
-
-    setInitialPartition(topicRes?.partitions?.length);
+    try {
+      const topicRes = await getTopic(topicName, config);
+      if (topicRes) {
+        if (isCreate) {
+          setInvalidText(t('topic.already_exists', { name: topicName }));
+          setTopicValidated('error');
+          setIsLoading(false);
+        } else {
+          setInitialPartition(topicRes?.partitions?.length);
+        }
+      }
+    } catch (err) {
+      if (isCreate && err.response.status == '404') {
+        setTopicValidated('default');
+        setIsLoading(false);
+        saveTopic();
+      }
+    }
   };
 
   useEffect(() => {
-    (async function () {
-      fetchTopic(topicData.name);
-    })();
     if (!isCreate) {
+      (async function () {
+        fetchTopic(topicData.name);
+      })();
       setCustomRetentionTimeUnit('milliseconds');
     }
   }, []);
@@ -169,17 +180,25 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
     const regexpInvalid = new RegExp('^[0-9A-Za-z_-]+$');
 
     if (value.length && !regexpInvalid.test(value)) {
-      setInvalidText(
-        'Invalid input. Only letters (Aa-Zz) , numbers " _ " and " - " are accepted'
-      );
-      setTopicValidated('error');
-    } else if (value.length < 1) {
-      setInvalidText('This is a required field');
+      setInvalidText(t('topic.topic_name_helper_text'));
       setTopicValidated('error');
     } else if (value.length > 249) {
       setTopicValidated('error');
-      setInvalidText('Topic name cannot exceed 249 characters');
+      setInvalidText(t('topic.cannot_exceed_characters'));
     } else setTopicValidated('default');
+  };
+
+  const partitionsWarnigCheckPlus = () => {
+    if (
+      initialPartition &&
+      Number(topicData.numPartitions + 1) > initialPartition
+    ) {
+      setPartitionsValidated('warning');
+      setWarning(true);
+    } else {
+      setPartitionsValidated('default');
+      setWarning(false);
+    }
   };
 
   const handleTextInputChange = (
@@ -221,18 +240,6 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
     setTopicData({ ...topicData, [kebabToCamel(fieldName)]: partitionValue });
   };
 
-  const partitionsWarnigCheckPlus = () => {
-    if (
-      initialPartition &&
-      Number(topicData.numPartitions + 1) > initialPartition
-    ) {
-      setPartitionsValidated('warning');
-      setWarning(true);
-    } else {
-      setPartitionsValidated('default');
-      setWarning(false);
-    }
-  };
   const handleTouchSpinPlusCamelCase = (event) => {
     const { name } = event.currentTarget;
     const fieldName = kebabToCamel(name);
@@ -338,8 +345,18 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
     setTopicData({ ...topicData, [kebabToDotSeparated(fieldName)]: value });
   };
   const onConfirm = () => {
-    if (warning) setIsWarningOpen(true);
-    else saveTopic();
+    if (!isCreate) {
+      if (warning) setIsWarningOpen(true);
+      else saveTopic();
+    } else {
+      if (topicData.name.length < 1) {
+        setInvalidText(t('topic.required'));
+        setTopicValidated('error');
+      } else {
+        setIsLoading(true);
+        fetchTopic(topicData.name);
+      }
+    }
   };
   const onSaveClick = () => {
     setIsWarningOpen(false);
@@ -486,6 +503,8 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
                     buttonAriaLabel='More info for topic name field'
                     helperTextInvalid={invalidText}
                     validated={topicValidated}
+                    isRequired={true}
+                    helperText={t('topic.topic_name_helper_text')}
                   >
                     <TextInput
                       isRequired
@@ -517,9 +536,7 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
                     buttonAriaLabel='More info for partitions field'
                     validated={partitionsValidated}
                     helperText={
-                      warning
-                        ? `Increasing a topic's partitions might result in messages having the same key from two different partitions, which can potentially break the message ordering guarantees that apply to a single partition`
-                        : undefined
+                      warning ? t('topic.partitions_warning') : undefined
                     }
                   >
                     <NumberInput
@@ -865,6 +882,7 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
           </Stack>
           <ActionGroup className='kafka-ui--sticky-footer'>
             <Button
+              isLoading={isLoading}
               onClick={onConfirm}
               variant='primary'
               data-testid={
@@ -872,11 +890,7 @@ export const TopicAdvanceConfig: React.FunctionComponent<ITopicAdvanceConfig> = 
                   ? 'topicAdvanceCreate-actionCreate'
                   : 'tabProperties-actionSave'
               }
-              isDisabled={
-                topicData.name.length > 0 && topicValidated == 'default'
-                  ? false
-                  : true
-              }
+              isDisabled={topicValidated == 'default' ? false : true}
             >
               {actionText}
             </Button>

--- a/src/Modules/Topics/CreateTopic/Components/WizardCustomFooter.tsx
+++ b/src/Modules/Topics/CreateTopic/Components/WizardCustomFooter.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  WizardContextConsumer,
+  Button,
+  WizardFooter,
+} from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+
+export interface IWizardFooter {
+  isLoading: boolean;
+  onValidate: (value: () => void) => void;
+  topicNameValidated: 'error' | 'default';
+  closeWizard: () => void;
+}
+export const WizardCustomFooter: React.FC<IWizardFooter> = ({
+  isLoading,
+  onValidate,
+  topicNameValidated,
+  closeWizard,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <WizardFooter>
+      <WizardContextConsumer>
+        {({ activeStep, onNext, onBack }) => {
+          if (activeStep.name == t('topic.topic_name')) {
+            return (
+              <>
+                <Button
+                  variant='primary'
+                  type='submit'
+                  isLoading={isLoading}
+                  onClick={() => onValidate(onNext)}
+                  isDisabled={topicNameValidated == 'default' ? false : true}
+                >
+                  {t('common.next')}
+                </Button>
+                <Button variant='secondary' isDisabled={true}>
+                  {t('common.back')}
+                </Button>
+                <Button variant='link' onClick={closeWizard}>
+                  {t('common.cancel')}
+                </Button>
+              </>
+            );
+          }
+
+          if (activeStep.name == 'Replicas') {
+            return (
+              <>
+                <Button variant='primary' type='submit' onClick={onNext}>
+                  {t('common.finish')}
+                </Button>
+                <Button variant='secondary' onClick={onBack}>
+                  {t('common.back')}
+                </Button>
+                <Button variant='link' onClick={closeWizard}>
+                  {t('common.cancel')}
+                </Button>
+              </>
+            );
+          }
+          return (
+            <>
+              <Button variant='primary' type='submit' onClick={onNext}>
+                {t('common.next')}
+              </Button>
+              <Button variant='secondary' onClick={onBack}>
+                {t('common.back')}
+              </Button>
+              <Button variant='link' onClick={closeWizard}>
+                {t('common.cancel')}
+              </Button>
+            </>
+          );
+        }}
+      </WizardContextConsumer>
+    </WizardFooter>
+  );
+};

--- a/src/Modules/Topics/CreateTopic/Tests/StepTopicName.test.tsx
+++ b/src/Modules/Topics/CreateTopic/Tests/StepTopicName.test.tsx
@@ -13,6 +13,8 @@ const setup = () => {
     setTopicNameInput: jest.fn(),
     topicNameValidated: 'default',
     setTopicNameValidated: jest.fn(),
+    invalidText: '',
+    setInvalidText: jest.fn(),
   };
   const component: ReactElement = (
     <I18nextProvider i18n={kafkai18n}>

--- a/src/Modules/Topics/TopicList/Components/SearchTopics.tsx
+++ b/src/Modules/Topics/TopicList/Components/SearchTopics.tsx
@@ -1,16 +1,24 @@
 import React from 'react';
-import { InputGroup, SearchInput } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  InputGroup,
+  TextInput,
+} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
+import { SearchIcon } from '@patternfly/react-icons';
 
 export interface ISearchTopicsProps {
   setSearch: (value: string) => void;
+  setSearchTopicName: (value: string) => void;
   search: string;
-  onClear: () => void;
+  setFilteredTopics: (value: boolean) => void;
 }
 const SearchTopics: React.FunctionComponent<ISearchTopicsProps> = ({
   search,
   setSearch,
-  onClear,
+  setFilteredTopics,
+  setSearchTopicName,
 }) => {
   const { t } = useTranslation();
 
@@ -18,13 +26,15 @@ const SearchTopics: React.FunctionComponent<ISearchTopicsProps> = ({
     setSearch(value);
   };
 
-  const onClearHandler = () => {
-    onClear();
+  const onSearch = () => {
+    setSearchTopicName(search);
+    setFilteredTopics(true);
     setSearch('');
   };
+
   return (
     <InputGroup>
-      <SearchInput
+      <TextInput
         name='searchName'
         id='search-topics-input'
         type='search'
@@ -32,8 +42,15 @@ const SearchTopics: React.FunctionComponent<ISearchTopicsProps> = ({
         placeholder={t('common.search')}
         value={search}
         onChange={onChangeInput}
-        onClear={onClearHandler}
       />
+      <Button
+        variant={ButtonVariant.control}
+        isDisabled={search.length ? false : true}
+        onClick={onSearch}
+        aria-label={t('topic.topic_search')}
+      >
+        <SearchIcon />
+      </Button>
     </InputGroup>
   );
 };

--- a/src/Modules/Topics/TopicList/Tests/SearchTopics.test.tsx
+++ b/src/Modules/Topics/TopicList/Tests/SearchTopics.test.tsx
@@ -7,7 +7,8 @@ describe('<SearchTopics />', () => {
   const props: ISearchTopicsProps = {
     setSearch: jest.fn(),
     search: 'Search',
-    onClear: jest.fn(),
+    setFilteredTopics: jest.fn(),
+    setSearchTopicName: jest.fn(),
   };
   xit('should render a search input', () => {
     const { getByText } = render(<SearchTopics {...props} />);

--- a/src/Services/TopicServices.ts
+++ b/src/Services/TopicServices.ts
@@ -11,7 +11,8 @@ import { IConfiguration } from '../Contexts';
 import { IAdvancedTopic } from 'src/Modules/Topics/CreateTopic/Components/CreateTopicWizard';
 
 export const getTopics = async (
-  config: IConfiguration | undefined
+  config: IConfiguration | undefined,
+  filter?: string
 ): Promise<TopicsList> => {
   const accessToken = await config?.getToken();
 
@@ -21,7 +22,10 @@ export const getTopics = async (
       basePath: config?.basePath,
     })
   );
-  const response: AxiosResponse<TopicsList> = await api.getTopicsList();
+  const response: AxiosResponse<TopicsList> = await api.getTopicsList(
+    100,
+    filter
+  );
   return response.data;
 };
 

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1,6 +1,8 @@
 {
   "common": {
     "delete": "Delete",
+    "next": "Next",
+    "back": "Back",
     "edit": "Edit",
     "name": "Name",
     "replicas": "Replicas",
@@ -27,7 +29,8 @@
     "confirm_delete": "Type DELETE to confirm:",
     "confirm_delete_modal_text": "<b>{{name}}</b> will be deleted.",
     "no_results_title": "No results found",
-    "no_results_body": "Adjust your filters and try again"
+    "no_results_body": "Adjust your filters and try again",
+    "clear_filters": "Clear all filters"
   },
   "topic": {
     "topics": "Topics",
@@ -42,6 +45,7 @@
     "jump_to_section": "JUMP TO SECTION",
     "topic_list_table": "Topic List Table",
     "topic_search_input": "Topic search input",
+    "topic_search": "Search topics button",
     "empty_list_head": "You don't have any topics yet",
     "empty_list_body": "Create a topic by clicking the button below to get started",
     "no_result_head": "No results found",
@@ -131,7 +135,11 @@
     "show_all_options": "Show all available options",
     "topic_successfully_created": "The topic was successfully created in the Kafka instance",
     "topic_successfully_updated": "The topic was successfully updated in the Kafka instance",
-    "topic_successfully_deleted": "Successfully deleted topic {{name}}"
+    "topic_successfully_deleted": "Successfully deleted topic {{name}}",
+    "partitions_warning": "Increasing a topic's partitions might result in messages having the same key from two different partitions, which can potentially break the message ordering guarantees that apply to a single partition",
+    "required": "Required",
+    "already_exists": "{{name}} already exists . Try a different name",
+    "cannot_exceed_characters": "Cannot exceed 249 characters"
   },
   "consumerGroup": {
     "consumer_groups": "Consumer Groups",


### PR DESCRIPTION
The topic validation PR has been closed and it's changes have been incorporated in this PR. I was facing a lot of merge conflicts and felt it was easier to transfer those changes on a separate PR. 
The following PR has thus been closed: [https://github.com/bf2fc6cc711aee1a0c2a/kafka-ui/pull/94](url)

This PR includes:

- Implement server side filtering of topics List
- Addresses a bug that did not show empty state until two characters were input in search 
- Implement Validation of topic name with appropriate error message 
