### PR TITLE
Increase character width of number inputs

### DIFF
--- a/src/components/SizeTimeFormGroup/SizeTimeFormGroup.tsx
+++ b/src/components/SizeTimeFormGroup/SizeTimeFormGroup.tsx
@@ -80,6 +80,7 @@ export const SizeTimeFormGroup: React.FC<SizeTimeFormGroup> = ({
           plusBtnProps={plusBtnProps}
           minusBtnProps={minusBtnProps}
           min={min}
+          widthChars={10}
         />
       </FlexItem>
       <FlexItem>


### PR DESCRIPTION
Increases the character width of the number input in `SizeTimeFormGroup `so that the large values aren't ellipsed and cut off.

![image](https://user-images.githubusercontent.com/19825616/121069936-13721000-c79c-11eb-84e8-97d4a508271e.png)

@dlabaj  @jgiardino 