### PR TITLE
Fix spacing in consumer group drawer

### DIFF
--- a/src/components/MASDrawer/MASDrawer.css
+++ b/src/components/MASDrawer/MASDrawer.css
@@ -1,0 +1,14 @@
+/* These styles override text content defaults */
+.kafka-ui-mas-drawer__top-label {
+    margin-bottom: 0 !important;
+}
+
+.kafka-ui-mas-drawer__title {
+    margin-top: 0 !important;
+}
+
+/* the drawer content body should be flex column in case there is >1 child */
+.kafka-ui-mas-drawer__drawer-content-body {
+    display: flex;
+    flex-direction: column;
+}

--- a/src/components/MASDrawer/MASDrawer.tsx
+++ b/src/components/MASDrawer/MASDrawer.tsx
@@ -19,6 +19,7 @@ import {
   DrawerContentBody,
 } from "@patternfly/react-core";
 import { MASLoading } from "@app/components";
+import "./MASDrawer.css";
 
 export type MASDrawerProps = DrawerProps & {
   children: React.ReactNode;
@@ -71,7 +72,7 @@ export const MASDrawer: React.FC<MASDrawerProps> = ({
               {text?.label && (
                 <Text
                   component={text?.component || TextVariants.small}
-                  className={text?.className || "pf-u-mb-0"}
+                  className={text?.className || "kafka-ui-mas-drawer__top-label"}
                 >
                   {text?.label}
                 </Text>
@@ -80,7 +81,7 @@ export const MASDrawer: React.FC<MASDrawerProps> = ({
                 <Title
                   headingLevel={title?.headingLevel || "h2"}
                   size={title?.size || TitleSizes["xl"]}
-                  className={title?.className || "pf-u-mt-0"}
+                  className={title?.className || "kafka-ui-mas-drawer__title"}
                 >
                   {title?.value}
                 </Title>
@@ -111,7 +112,7 @@ export const MASDrawer: React.FC<MASDrawerProps> = ({
           notRequiredDrawerContentBackground ? "pf-m-no-background" : ""
         }
       >
-        <DrawerContentBody className="pf-u-display-flex pf-u-flex-direction-column">
+        <DrawerContentBody className="kafka-ui-mas-drawer__drawer-content-body">
           {children}
         </DrawerContentBody>
       </DrawerContent>

--- a/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
@@ -6,6 +6,7 @@ import {
   TextContent,
   Text,
   TextVariants,
+  Stack,
 } from "@patternfly/react-core";
 import { TableVariant } from "@patternfly/react-table";
 import { ConsumerGroup } from "@app/openapi";
@@ -47,7 +48,7 @@ export const ConsumerGroupDetail: React.FunctionComponent<ConsumerGroupDetailPro
   };
 
   return (
-    <>
+    <Stack hasGutter>
       <TextContent>
         <Flex>
           <FlexItem>
@@ -82,6 +83,6 @@ export const ConsumerGroupDetail: React.FunctionComponent<ConsumerGroupDetailPro
           variant: TableVariant.compact,
         }}
       />
-    </>
+    </Stack>
   );
 };


### PR DESCRIPTION
Utility classes are not being pulled in, so I replaced them with custom classes. I also added a stack layout to space the table from the content above.

![image](https://user-images.githubusercontent.com/19825616/121088895-65bf2b00-c7b4-11eb-8a6b-8d0501ed6a94.png)

@dlabaj @jgiardino 
