### PR TITLE
fix: restrict replication factor in topic patch

### DIFF
--- a/src/modules/Topics/components/UpdateTopicView/UpdateTopicView.tsx
+++ b/src/modules/Topics/components/UpdateTopicView/UpdateTopicView.tsx
@@ -93,7 +93,7 @@ export const UpdateTopicView: React.FunctionComponent<UpdateTopicViewProps> = ({
 
     for (const key in configEntries) {
       // TODO Remove check when API supports setting the number of partition
-      if (key && key !== 'numPartitions') {
+      if (key && key !== 'numPartitions' && key !== 'replicationFactor') {
         newConfig.push({
           key,
           value: configEntries[key].toString().toLowerCase(),


### PR DESCRIPTION
Replication factor was wrongly getting sent along with the patch topic payload.