### PR TITLE
Adding popover for Partitions with lag

### DIFF
--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -167,6 +167,8 @@
     "consumer_group_search": "Search consumer group button",
     "active_members": "Active members",
     "partitions_with_lag": "Partitions with lag",
+    "partitions_with_lag_name": "Partitions with lag",
+    "partitions_with_lag_description": "Partitions with lag shows the number of partitions where the assigned consumer has not caught up with the last message in the partition. The offset lag of a partition reflects the current offset position of a consumer in relation to the end of the partition log. Use this number to identify any delay in the consumption of messages. To reduce consumer lag, you typically add new consumers to a group.",
     "uncosumed_partitions": "Unconsumed partitions",
     "uncosumed_partitions_for_topic": "Unconsumed partitions for this topic",
     "state": "State",

--- a/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
@@ -11,6 +11,7 @@ import {
 import { TableVariant, wrappable, cellWidth } from '@patternfly/react-table';
 import { ConsumerGroup } from '@rhoas/kafka-instance-sdk';
 import { MASTable } from '@app/components';
+import { ConsumerGroupPopover } from '@app/modules/ConsumerGroups/components';
 
 export type ConsumerGroupDetailProps = {
   consumerGroupDetail: ConsumerGroup | undefined;
@@ -113,7 +114,8 @@ const ConsumerGroupDetail: React.FunctionComponent<ConsumerGroupDetailProps> =
           <Flex>
             <FlexItem>
               <Text component={TextVariants.h4} size={50}>
-                {t('consumerGroup.active_members')}
+                {t('consumerGroup.active_members')}{' '}
+
               </Text>
               <Text component={TextVariants.p}>
                 <Text component={TextVariants.h2}>
@@ -126,7 +128,8 @@ const ConsumerGroupDetail: React.FunctionComponent<ConsumerGroupDetailProps> =
             </FlexItem>
             <FlexItem>
               <Text component={TextVariants.h4}>
-                {t('consumerGroup.partitions_with_lag')}
+                {t('consumerGroup.partitions_with_lag')}{' '}
+                <ConsumerGroupPopover title={t('consumerGroup.partitions_with_lag_name')} description={t('consumerGroup.partitions_with_lag_description')} />
               </Text>
               <Text component={TextVariants.p}>
                 <Text component={TextVariants.h2}>

--- a/src/modules/ConsumerGroups/components/ConsumerGroupsPopover.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupsPopover.tsx
@@ -1,0 +1,16 @@
+import { Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+type ConsumerGroupPopoverProps = {
+  title: string;
+  description: string;
+};
+
+export const ConsumerGroupPopover = ({ title, description }: ConsumerGroupPopoverProps) => {
+  return (
+    <Popover aria-label="Consumer groups popover" headerContent={<div>{title}</div>} bodyContent={<div>{description}</div>}>
+      <OutlinedQuestionCircleIcon />
+    </Popover>
+  );
+};

--- a/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
@@ -7,6 +7,7 @@ import {
   OnSort,
   ISortBy,
   sortable,
+  info,
 } from '@patternfly/react-table';
 import { ConsumerGroup } from '@rhoas/kafka-instance-sdk';
 import {
@@ -56,7 +57,15 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
   const tableColumns = [
     { title: t('consumerGroup.consumer_group_id'), transforms: [sortable] },
     { title: t('consumerGroup.active_members') },
-    { title: t('consumerGroup.partitions_with_lag') },
+    { title: t('consumerGroup.partitions_with_lag'), transforms: [info({
+      popover: (
+        <div>
+          {t('consumerGroup.partitions_with_lag_description')}
+        </div>
+      ),
+      ariaLabel: 'partions with lag',
+      popoverProps: {headerContent: (t('consumerGroup.partitions_with_lag_name'))}
+    })]},
   ];
 
   useEffect(() => {

--- a/src/modules/ConsumerGroups/components/index.ts
+++ b/src/modules/ConsumerGroups/components/index.ts
@@ -1,2 +1,3 @@
 export * from './ConsumerGroupDetail';
 export * from './ConsumerGroupsTable';
+export * from './ConsumerGroupsPopover';


### PR DESCRIPTION
Adding popover for **Partitions with lag** for Consumer Groups as per the docs 
