### PR TITLE
Adding wildcard entry to access modal

### DIFF
--- a/src/modules/Permissions/components/ManagePermissionsDialog/CreatePermissions.tsx
+++ b/src/modules/Permissions/components/ManagePermissionsDialog/CreatePermissions.tsx
@@ -299,18 +299,25 @@ export const CreatePermissions: React.FunctionComponent<CreatePermissionsProps> 
             return [];
           }}
           onSelect={(value) => {
-            const errorMessage = validateName(value);
-            if (errorMessage !== undefined) {
-              setAcls((prevState) => {
-                prevState[row].resource.validated = 'error';
-                prevState[row].resource.errorMessage = errorMessage;
-                return prevState;
-              });
-            } else if (value !== undefined) {
+            if (value === '*') {
               setAcls((prevState) => {
                 prevState[row].resource.validated = 'default';
                 return prevState;
               });
+            } else {
+              const errorMessage = validateName(value);
+              if (errorMessage !== undefined) {
+                setAcls((prevState) => {
+                  prevState[row].resource.validated = 'error';
+                  prevState[row].resource.errorMessage = errorMessage;
+                  return prevState;
+                });
+              } else if (value !== undefined) {
+                setAcls((prevState) => {
+                  prevState[row].resource.validated = 'default';
+                  return prevState;
+                });
+              }
             }
           }}
         />

--- a/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.tsx
+++ b/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.tsx
@@ -150,6 +150,8 @@ export const ManagePermissionsModal: React.FC<
                 'permission.manage_permissions_dialog.assign_permissions.must_select_resource_error'
               );
               valid = false;
+            } else if (value.resource.value === '*') {
+              answer.resource.validated = 'default';
             } else {
               const errorMessage = validateName(value.resource.value);
               if (errorMessage !== undefined) {


### PR DESCRIPTION
Adding wildcard entry for the 3rd tab of **Resource**  in Manage access modal

When the user enters the wildcard character * (asterisk) in the 3rd input user should not see any error
![Screenshot from 2021-10-13 19-47-37](https://user-images.githubusercontent.com/53568062/137151452-8a47b9fe-09c9-4cbe-b635-25eef52f5ca5.png)

When the user enters the wildcard character * (asterisk) with one or more characters, should see an error message 
![Screenshot from 2021-10-13 19-51-07](https://user-images.githubusercontent.com/53568062/137151979-e993e53d-5ab5-4ad6-bfd2-1193cbffb6c6.png)


