### PR TITLE
5829 Fix cut off dropdowns in permissions modal

### DIFF
--- a/src/modules/Permissions/components/ManagePermissionsDialog/CreateSelect.tsx
+++ b/src/modules/Permissions/components/ManagePermissionsDialog/CreateSelect.tsx
@@ -100,6 +100,7 @@ export const CreateSelect = <
         validated={selected.validated || 'default'}
         menuAppendTo={menuAppendTo}
         maxHeight={200}
+        direction={'up'}
       >
         {options.map((option, index) => (
           <PFSelectOption

--- a/src/modules/Permissions/components/ManagePermissionsDialog/CreateTypeahead.tsx
+++ b/src/modules/Permissions/components/ManagePermissionsDialog/CreateTypeahead.tsx
@@ -112,6 +112,7 @@ export const CreateTypeahead: React.FunctionComponent<CreateTypeaheadProps> = ({
         validated={value.validated || 'default'}
         menuAppendTo={menuAppendTo}
         maxHeight={200}
+        direction={'up'}
       >
         {options.map((option, index) => (
           <PFSelectOption

--- a/src/modules/Permissions/components/ManagePermissionsDialog/SelectAccount.tsx
+++ b/src/modules/Permissions/components/ManagePermissionsDialog/SelectAccount.tsx
@@ -81,6 +81,7 @@ export const SelectAccount: React.FunctionComponent<SelectAccountProps> = ({
     >
       <Select
         variant={SelectVariant.typeahead}
+        className='kafka-ui--select--limit-height'
         typeAheadAriaLabel={t(
           'permission.manage_permissions_dialog.account_id_typeahead_aria'
         )}
@@ -95,7 +96,6 @@ export const SelectAccount: React.FunctionComponent<SelectAccountProps> = ({
         )}
         isCreatable={false}
         menuAppendTo='parent'
-        maxHeight={400}
         validated={id.validated || 'default'}
         isGrouped={true}
       >

--- a/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.css
+++ b/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.css
@@ -1,0 +1,19 @@
+/* Custom styles for manage permissions dialog */
+
+/* Adjust the height of the dropdown so that it doesn't extend past the end of the page. Don't set height on the component because it is inline and will override this. */
+.kafka-ui--select--limit-height .pf-c-select__menu {
+  max-height: 120px;
+  overflow: auto;
+
+  @media (min-height: 485px) {
+    max-height: 225px;
+  }
+
+  @media (min-height: 560px) {
+    max-height: 300px;
+  }
+
+  @media (min-height: 660px) {
+    max-height: 400px;
+  }
+}

--- a/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.tsx
+++ b/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.tsx
@@ -33,6 +33,7 @@ import {
   AclResourceType,
   AclResourceTypeFilter,
 } from '@rhoas/kafka-instance-sdk';
+import './ManagePermissions.css';
 
 export const ManagePermissions: React.FC<
   ManagePermissionsProps & BaseModalProps


### PR DESCRIPTION
This fixes the select dropdowns in the permissions modal that are being cut off if the screen is too short. For the account selection, a responsive media query is used to adjust the max-height of the expanded dropdown. For the selects in the permissions builder, they are set to expand up rather than down.

Responsive height:
https://user-images.githubusercontent.com/19825616/137162409-ba34cca2-17e1-4186-877a-3332d1ac5e79.mp4

Expand selects up rather than down
https://user-images.githubusercontent.com/19825616/137162486-79908de6-7419-462a-b725-65bce674dbe6.mp4

@lclay2 @jgiardino 

