### PR TITLE
Fix search filter for access management modal

### DIFF
--- a/src/modules/Permissions/components/ManagePermissionsDialog/SelectAccount.tsx
+++ b/src/modules/Permissions/components/ManagePermissionsDialog/SelectAccount.tsx
@@ -130,15 +130,13 @@ export const SelectAccount: React.FunctionComponent<SelectAccountProps> = ({
 
     const input = new RegExp(value, 'i');
     return options
-      .filter(
-        (accounts) =>
-          accounts.props.label === 'Service accounts' ||
-          accounts.props.label === 'User accounts'
-      )[0]
-      .props.children.filter(
-        (serviceAccounts) =>
-          input.test(serviceAccounts.props.value) ||
-          input.test(serviceAccounts.props.description)
+      .filter((accounts) => Array.isArray(accounts.props.children))
+      .map((account) =>
+        account.props.children.filter(
+          (allAccounts) =>
+            input.test(allAccounts.props.value) ||
+            input.test(allAccounts.props.description)
+        )
       );
   };
 


### PR DESCRIPTION
This PR fixes the following bugs:

- Filter is now applied to both the ID (value) and the name(description)
- Filter works even if the value specified by the user does not match the beginning of an ID/name

![Screenshot from 2021-10-27 17-48-31](https://user-images.githubusercontent.com/66817941/139065623-9cc79c2c-51ad-44e1-9fe3-50218c4fd007.png)
![Screenshot from 2021-10-27 17-48-22](https://user-images.githubusercontent.com/66817941/139065630-2263d0fc-4944-4134-9d57-2a49464a750f.png)

