### PR TITLE
Updating the kafka ACLs table sort order

### DIFF
--- a/src/modules/Permissions/components/PermissionsTable/PermissionsTable.tsx
+++ b/src/modules/Permissions/components/PermissionsTable/PermissionsTable.tsx
@@ -106,13 +106,13 @@ const PermissionsTable: React.FC<PermissionsTableProps> = ({
   useTimeout(() => fetchPermissions(), 5000);
 
   const tableColumns = [
-    { title: t('permission.table.resource_column_title') },
-    { title: t('permission.table.permissions_column_title') },
     { title: t('permission.table.account_column_title') },
+    { title: t('permission.table.permissions_column_title') },
+    { title: t('permission.table.resource_column_title') },
     { title: '' },
   ] as ICell[];
 
-  const cells = [resourceCell, permissionOperationCell, principalCell];
+  const cells = [principalCell, permissionOperationCell, resourceCell];
 
   const onSelect: OnSelect = (event, isSelected, rowIndex) => {
     if (rowIndex === -1) {

--- a/src/services/acls.ts
+++ b/src/services/acls.ts
@@ -155,18 +155,18 @@ const enhanceAclBindingListPage = (
         } as EnhancedAclBinding;
       })
       .sort((a, b) => {
-        if (a.permission !== b.permission) {
-          if (a.permission === 'DENY') {
-            return -1;
-          } else {
-            return 1;
-          }
-        } else if (a.principal !== b.principal) {
+        if (a.principal !== b.principal) {
           return a.principal.localeCompare(b.principal);
         } else if (a.resourceType !== b.resourceType) {
           return a.resourceType.localeCompare(b.resourceType);
         } else if (a.resourceName !== b.resourceName) {
           return a.resourceName.localeCompare(b.resourceName);
+        } else if (a.permission !== b.permission) {
+          if (a.permission === 'DENY') {
+            return -1;
+          } else {
+            return 1;
+          }
         } else if (a.operation !== b.operation) {
           return a.operation.localeCompare(b.operation);
         } else {


### PR DESCRIPTION
Updating the Kafka ACLs table sort order

sorted according to the below sort order
![Screenshot from 2022-01-10 12-59-39](https://user-images.githubusercontent.com/53568062/148731005-e30c8b65-6742-46b3-9217-b84749bdaa35.png)

output
![Acl table](https://user-images.githubusercontent.com/53568062/148731091-47c0f4d2-87df-4849-98cf-e8e37cb4c737.png)
