### PR TITLE
Add state column to the consumer group table

### DIFF
--- a/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
@@ -12,6 +12,7 @@ import { TableVariant, wrappable, cellWidth } from '@patternfly/react-table';
 import { ConsumerGroup } from '@rhoas/kafka-instance-sdk';
 import { MASTable } from '@app/components';
 import { ConsumerGroupPopover } from '@app/modules/ConsumerGroups/components';
+import { State } from '@app/modules/ConsumerGroups/components/utils';
 
 export type ConsumerGroupDetailProps = {
   consumerGroupDetail: ConsumerGroup | undefined;
@@ -146,6 +147,14 @@ const ConsumerGroupDetail: React.FunctionComponent<
                   consumerGroupDetail.consumers.reduce(function (prev, cur) {
                     return prev + (cur.lag > 0 ? 1 : 0);
                   }, 0)}
+              </Text>
+            </Text>
+          </FlexItem>
+          <FlexItem>
+            <Text component={TextVariants.h4}>{t('consumerGroup.state')}</Text>
+            <Text component={TextVariants.p}>
+              <Text component={TextVariants.h2}>
+                {State[consumerGroupDetail?.state]}
               </Text>
             </Text>
           </FlexItem>

--- a/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
@@ -21,6 +21,7 @@ import {
   ConsumerGroupToolbarProps,
 } from './ConsumerGroupToolbar';
 import { ModalType, useModal } from '@rhoas/app-services-ui-shared';
+import { State } from '@app/modules/ConsumerGroups/components/utils';
 
 export type ConsumerGroupsTableProps = ConsumerGroupToolbarProps & {
   consumerGroups?: ConsumerGroup[];
@@ -71,6 +72,7 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
         }),
       ],
     },
+    { title: t('consumerGroup.state') },
   ];
 
   useEffect(() => {
@@ -82,7 +84,7 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
   const preparedTableCells = () => {
     const tableRow: (IRowData | string[])[] | undefined = [];
     consumerGroups?.map((row: IRowData) => {
-      const { groupId, consumers } = row;
+      const { groupId, consumers, state } = row;
       tableRow.push({
         cells: [
           groupId,
@@ -92,10 +94,12 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
           consumers.reduce(function (prev, cur) {
             return prev + (cur.lag > 0 ? 1 : 0);
           }, 0),
+          State[state],
         ],
         originalData: { ...row, rowId: groupId },
       });
     });
+
     return tableRow;
   };
 

--- a/src/modules/ConsumerGroups/components/index.ts
+++ b/src/modules/ConsumerGroups/components/index.ts
@@ -1,3 +1,4 @@
 export * from './ConsumerGroupDetail';
 export * from './ConsumerGroupsTable';
 export * from './ConsumerGroupsPopover';
+export * from './utils';

--- a/src/modules/ConsumerGroups/components/utils/index.ts
+++ b/src/modules/ConsumerGroups/components/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/src/modules/ConsumerGroups/components/utils/utils.ts
+++ b/src/modules/ConsumerGroups/components/utils/utils.ts
@@ -1,0 +1,8 @@
+export enum State {
+  STABLE = 'Stable',
+  DEAD = 'Dead',
+  EMPTY = 'Empty',
+  COMPLETING_REBALANCE = 'Completing rebalance',
+  PREPARING_REBALANCE = 'Preparing rebalance',
+  UNKNOWN = 'Unknown',
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDSTRM-7500


1. **Kafka level**
- [x]  Include an additional column in the table views listing consumer groups
![Screenshot from 2022-02-23 20-02-02](https://user-images.githubusercontent.com/53568062/155339847-846cc6a0-0744-42f8-84fe-3fc980b54289.png)


- [x]  Include an additional property in the drawer showing details about a consumer group
![Screenshot from 2022-02-23 20-01-37](https://user-images.githubusercontent.com/53568062/155339883-4b16c5a4-f267-4d79-8b99-07bdb9a5e139.png)

2. **Topic Level**
![Screenshot from 2022-02-24 13-37-54](https://user-images.githubusercontent.com/53568062/155483951-9b3a69d6-a53f-4468-b935-c0bc87a4f7e0.png)




