### PR TITLE
[Bug] fix reset offset value update issue on drawer in  consumer group table

### DIFF
--- a/src/modules/ConsumerGroups/ConsumerGroups.tsx
+++ b/src/modules/ConsumerGroups/ConsumerGroups.tsx
@@ -86,8 +86,9 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
     //so that values will update on page
     const filteredGroup =
       consumerGroups &&
-      consumerGroups.items?.filter((g) => g.groupId === groupId)[0];
-    if (filteredGroup) setConsumerGroupDetail(filteredGroup);
+      consumerGroups.items?.filter((g) => g.groupId === groupId);
+    if (filteredGroup && filteredGroup.length > 0)
+      setConsumerGroupDetail(filteredGroup[0]);
   }, [consumerGroups]);
 
   useTimeout(() => fetchConsumerGroups(), 5000);

--- a/src/modules/ConsumerGroups/ConsumerGroups.tsx
+++ b/src/modules/ConsumerGroups/ConsumerGroups.tsx
@@ -44,6 +44,8 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
   const [search, setSearch] = useState<string>('');
   const [consumerGroupDetail, setConsumerGroupDetail] =
     useState<ConsumerGroup>();
+  const [groupId, setGroupId] = useState<string>();
+
   const config = useContext(ConfigContext);
   const { t } = useTranslation(['kafkaTemporaryFixMe']);
   const { page = 1, perPage = 10 } = usePaginationParams() || {};
@@ -79,6 +81,15 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
     fetchConsumerGroups();
   }, [search, order]);
 
+  useEffect(() => {
+    //update setConsumerGroupDetail state after reset offset value
+    //so that values will update on page
+    const filteredGroup =
+      consumerGroups &&
+      consumerGroups.items?.filter((g) => g.groupId === groupId)[0];
+    if (filteredGroup) setConsumerGroupDetail(filteredGroup);
+  }, [consumerGroups]);
+
   useTimeout(() => fetchConsumerGroups(), 5000);
 
   const panelBodyContent = (
@@ -94,6 +105,7 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
 
   const onViewConsumerGroup = (consumerGroup) => {
     setIsExpanded(true);
+    setGroupId(consumerGroup?.groupId);
     setConsumerGroupDetail(consumerGroup);
   };
 


### PR DESCRIPTION
Partition Offset in UI is not updated after the offset has been reset
https://issues.redhat.com/browse/MGDSTRM-5206

![image](https://user-images.githubusercontent.com/11775081/156632047-31a27abe-ced9-4197-8df2-a75cca6b8d18.png)
