### PR TITLE
fix: remove invalid logic for calculating active members and partitio…

### DIFF
--- a/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
@@ -126,10 +126,7 @@ const ConsumerGroupDetail: React.FunctionComponent<
             </Text>
             <Text component={TextVariants.p}>
               <Text component={TextVariants.h2}>
-                {consumerGroupDetail &&
-                  consumerGroupDetail.consumers.reduce(function (prev, cur) {
-                    return prev + (cur.partition != -1 ? 1 : 0);
-                  }, 0)}
+                {consumerGroupDetail?.metrics?.activeConsumers || 0}
               </Text>
             </Text>
           </FlexItem>
@@ -143,10 +140,7 @@ const ConsumerGroupDetail: React.FunctionComponent<
             </Text>
             <Text component={TextVariants.p}>
               <Text component={TextVariants.h2}>
-                {consumerGroupDetail &&
-                  consumerGroupDetail.consumers.reduce(function (prev, cur) {
-                    return prev + (cur.lag > 0 ? 1 : 0);
-                  }, 0)}
+              {consumerGroupDetail?.metrics?.laggingPartitions || 0}
               </Text>
             </Text>
           </FlexItem>


### PR DESCRIPTION
…n lag

With new SDK those values are actually calculated on the backend. 
I would need help if we actually have any of those values calculated in other places. 

I do not see any use case for unassignedPartitions number that is also returned from backend. Is that calculated somewhere else.