### PR TITLE
correct the number of Active members in consumer group UI

### DIFF
--- a/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
@@ -126,9 +126,7 @@ const ConsumerGroupDetail: React.FunctionComponent<
             </Text>
             <Text component={TextVariants.p}>
               <Text component={TextVariants.h2}>
-                {(consumerGroupDetail &&
-                  consumerGroupDetail.metrics?.activeConsumers) ||
-                  0}
+                {consumerGroupDetail?.metrics?.activeConsumers || 0}
               </Text>
             </Text>
           </FlexItem>

--- a/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
@@ -126,10 +126,9 @@ const ConsumerGroupDetail: React.FunctionComponent<
             </Text>
             <Text component={TextVariants.p}>
               <Text component={TextVariants.h2}>
-                {consumerGroupDetail &&
-                  consumerGroupDetail.consumers.reduce(function (prev, cur) {
-                    return prev + (cur.partition != -1 ? 1 : 0);
-                  }, 0)}
+                {(consumerGroupDetail &&
+                  consumerGroupDetail.metrics?.activeConsumers) ||
+                  0}
               </Text>
             </Text>
           </FlexItem>
@@ -143,10 +142,7 @@ const ConsumerGroupDetail: React.FunctionComponent<
             </Text>
             <Text component={TextVariants.p}>
               <Text component={TextVariants.h2}>
-                {consumerGroupDetail &&
-                  consumerGroupDetail.consumers.reduce(function (prev, cur) {
-                    return prev + (cur.lag > 0 ? 1 : 0);
-                  }, 0)}
+                {consumerGroupDetail?.metrics?.laggingPartitions || 0}
               </Text>
             </Text>
           </FlexItem>

--- a/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
@@ -90,16 +90,12 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
   const preparedTableCells = () => {
     const tableRow: (IRowData | string[])[] | undefined = [];
     consumerGroups?.map((row: IRowData) => {
-      const { groupId, consumers, state } = row;
+      const { groupId, state, metrics } = row;
       tableRow.push({
         cells: [
           groupId,
-          consumers.reduce(function (prev: number, cur: { partition: number }) {
-            return prev + (cur.partition != -1 ? 1 : 0);
-          }, 0),
-          consumers.reduce(function (prev: number, cur: { lag: number }) {
-            return prev + (cur.lag > 0 ? 1 : 0);
-          }, 0),
+          metrics.activeConsumers,
+          metrics.laggingPartitions,
           ConsumerGroupState(state),
         ],
         originalData: { ...row, rowId: groupId },


### PR DESCRIPTION
**What this PR does / why we need it:**

correct the number of Active members in the consumer group UI

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/MGDSTRM-6185
https://issues.redhat.com/browse/MGDSTRM-6186

**Output**
![Screenshot from 2022-04-11 21-17-12](https://user-images.githubusercontent.com/53568062/162779765-cb92b950-e0e3-49aa-98ea-e769a421627f.png)

Special notes for your reviewer:
since it's the backend code change and user-facing UI bugs, fixing it for now