### PR TITLE
fix: show existing ACLs in the Manage Permissions dialog

### DIFF
--- a/src/modules/Permissions/components/PermissionsTable/PermissionsTable.tsx
+++ b/src/modules/Permissions/components/PermissionsTable/PermissionsTable.tsx
@@ -33,7 +33,12 @@ import {
   ModalTypePropsMap,
   useModal,
 } from '@rhoas/app-services-ui-shared';
-import { MASPagination, MASTable, usePaginationParams } from '@app/components';
+import {
+  Loading,
+  MASPagination,
+  MASTable,
+  usePaginationParams,
+} from '@app/components';
 
 export type PermissionsTableProps = {
   permissionsService: PermissionsService;
@@ -229,11 +234,10 @@ const PermissionsTable: React.FC<PermissionsTableProps> = ({
     return resolver;
   };
 
-  if (
-    aclPage === undefined ||
-    aclPage.items === undefined ||
-    aclPage.items.length === 0
-  ) {
+  if (aclPage === undefined) {
+    return <Loading />;
+  }
+  if (aclPage.items === undefined || aclPage.items.length === 0) {
     return (
       <PermissionsTableEmptyState
         openManagePermissions={() => openManagePermissions()}

--- a/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.tsx
+++ b/src/modules/Permissions/dialogs/ManagePermissions/ManagePermissions.tsx
@@ -371,6 +371,12 @@ export const ManagePermissionsModal: React.FC<
     setIsOpenPreCancelModal(false);
   };
 
+  const aclsForSelectedAccount = (acls || []).filter(
+    (i) =>
+      (selectedAccount.value && i.principal === `${selectedAccount.value}`) ||
+      i.principal === '*'
+  );
+
   return (
     <Modal
       id='manage-permissions-modal'
@@ -462,10 +468,10 @@ export const ManagePermissionsModal: React.FC<
             }
             setAcls={setNewAcls}
             setEscapeClosesModal={setEscapeClosesModal}
-            acls={acls}
+            acls={aclsForSelectedAccount}
             consumerGroupIds={consumerGroupIds}
             selectedAccount={selectedAccount}
-            selectedAccountId={selectedAccountId}
+            selectedAccountId={selectedAccount.value}
             newAcls={newAcls}
             topicNames={topicNames}
             resourceOperations={resourceOperations}
@@ -515,10 +521,7 @@ const Step2: VoidFunctionComponent<Step2Props> = ({
         </FormAlert>
       )}
       <ExistingAclTable
-        existingAcls={(acls || []).filter(
-          (i) =>
-            i.principal === `${selectedAccount.value}` || i.principal === '*'
-        )}
+        existingAcls={acls}
         selectedAccountId={selectedAccountId}
         onRemove={onRemoveAcl}
       />


### PR DESCRIPTION
Also, shows a spinner instead of briefly showing the empty state for the permissions table the first time the page is loaded.