### PR TITLE
fix searching and pagination bugs for topics and consumers page

### DIFF
--- a/src/modules/ConsumerGroups/ConsumerGroups.tsx
+++ b/src/modules/ConsumerGroups/ConsumerGroups.tsx
@@ -119,56 +119,6 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
     setConsumerGroupDetail(consumerGroup);
   };
 
-  const RenderTable = () => {
-    switch (true) {
-      case consumerGroups === undefined:
-        return (
-          <PageSection
-            className='kafka-ui-m-full-height'
-            variant={PageSectionVariants.light}
-            padding={{ default: 'noPadding' }}
-          >
-            <MASLoading />
-          </PageSection>
-        );
-      case (!consumerGroups?.items?.length ||
-        consumerGroups?.items?.length < 1) &&
-        search.length < 1:
-        return (
-          <EmptyState
-            emptyStateProps={{
-              variant: MASEmptyStateVariant.NoConsumerGroups,
-            }}
-            titleProps={{
-              title: t('consumerGroup.empty_consumer_title'),
-            }}
-            emptyStateBodyProps={{
-              body: t('consumerGroup.empty_consumer_body'),
-            }}
-          />
-        );
-      case consumerGroups?.items !== undefined:
-        return (
-          <ConsumerGroupsTable
-            consumerGroups={consumerGroups?.items}
-            total={consumerGroups?.total || 0}
-            page={page}
-            perPage={perPage}
-            search={search}
-            setSearch={onSearch}
-            rowDataTestId={rowDataTestId}
-            onViewConsumerGroup={onViewConsumerGroup}
-            isDrawerOpen={isExpanded}
-            refreshConsumerGroups={fetchConsumerGroups}
-            onSort={onSort}
-            sortBy={sortBy}
-          />
-        );
-      default:
-        return <></>;
-    }
-  };
-
   return (
     <Suspense fallback={<MASLoading />}>
       <MASDrawer
@@ -183,7 +133,55 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
         refreshConsumerGroups={fetchConsumerGroups}
         consumerGroupDetail={consumerGroupDetail}
       >
-        <RenderTable />
+        {(() => {
+          switch (true) {
+            case consumerGroups === undefined:
+              return (
+                <PageSection
+                  className='kafka-ui-m-full-height'
+                  variant={PageSectionVariants.light}
+                  padding={{ default: 'noPadding' }}
+                >
+                  <MASLoading />
+                </PageSection>
+              );
+            case (!consumerGroups?.items?.length ||
+              consumerGroups?.items?.length < 1) &&
+              search.length < 1:
+              return (
+                <EmptyState
+                  emptyStateProps={{
+                    variant: MASEmptyStateVariant.NoConsumerGroups,
+                  }}
+                  titleProps={{
+                    title: t('consumerGroup.empty_consumer_title'),
+                  }}
+                  emptyStateBodyProps={{
+                    body: t('consumerGroup.empty_consumer_body'),
+                  }}
+                />
+              );
+            case consumerGroups?.items !== undefined:
+              return (
+                <ConsumerGroupsTable
+                  consumerGroups={consumerGroups?.items}
+                  total={consumerGroups?.total || 0}
+                  page={page}
+                  perPage={perPage}
+                  search={search}
+                  setSearch={onSearch}
+                  rowDataTestId={rowDataTestId}
+                  onViewConsumerGroup={onViewConsumerGroup}
+                  isDrawerOpen={isExpanded}
+                  refreshConsumerGroups={fetchConsumerGroups}
+                  onSort={onSort}
+                  sortBy={sortBy}
+                />
+              );
+            default:
+              return <></>;
+          }
+        })()}
       </MASDrawer>
     </Suspense>
   );

--- a/src/modules/ConsumerGroups/ConsumerGroups.tsx
+++ b/src/modules/ConsumerGroups/ConsumerGroups.tsx
@@ -40,7 +40,6 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
   topic,
   rowDataTestId,
 }) => {
-  const [offset, setOffset] = useState<number>(0);
   const [order, setOrder] = useState<SortByDirection>();
   const [orderKey, setOrderKey] = useState<'name' | undefined>();
   const [sortBy, setSortBy] = useState<ISortBy>({
@@ -56,11 +55,15 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
 
   const config = useContext(ConfigContext);
   const { t } = useTranslation(['kafkaTemporaryFixMe']);
-  const { page = 1, perPage = 10 } = usePaginationParams() || {};
+  const { page = 1, perPage = 10, setPage } = usePaginationParams() || {};
 
-  useEffect(() => {
-    setOffset(perPage * (page - 1));
-  }, [page, perPage]);
+  const onSearch = useCallback(
+    (value: string) => {
+      setSearch(value);
+      setPage && setPage(1);
+    },
+    [setPage]
+  );
 
   const onSort: OnSort = (_event, index, direction) => {
     setOrder(direction);
@@ -69,11 +72,8 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
   };
 
   const fetchConsumerGroups = useCallback(async () => {
-    const limit = 100;
     await getConsumerGroups(
       config,
-      offset,
-      limit,
       perPage,
       page,
       topic,
@@ -83,20 +83,19 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
     ).then((response) => {
       setConsumerGroups(response);
     });
-  }, [config, offset, order, orderKey, page, perPage, search, topic]);
+  }, [config, order, orderKey, page, perPage, search, topic]);
 
   useEffect(() => {
     fetchConsumerGroups();
-  }, [search, order, fetchConsumerGroups]);
+  }, [search, order, page, perPage, fetchConsumerGroups]);
 
   useEffect(() => {
     //update setConsumerGroupDetail state after reset offset value
     //so that values will update on page
     const filteredGroup =
       consumerGroups &&
-      consumerGroups.items?.filter((g) => g.groupId === groupId);
-    if (filteredGroup && filteredGroup.length > 0)
-      setConsumerGroupDetail(filteredGroup[0]);
+      consumerGroups.items?.find((g) => g.groupId === groupId);
+    if (filteredGroup) setConsumerGroupDetail(filteredGroup);
   }, [consumerGroups, groupId]);
 
   useTimeout(() => fetchConsumerGroups(), 5000);
@@ -120,60 +119,54 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
     setConsumerGroupDetail(consumerGroup);
   };
 
-  const renderConsumerTable = () => {
-    if (consumerGroups === undefined) {
-      return (
-        <PageSection
-          className='kafka-ui-m-full-height'
-          variant={PageSectionVariants.light}
-          padding={{ default: 'noPadding' }}
-        >
-          <MASLoading />
-        </PageSection>
-      );
-    } else if (
-      (!consumerGroups?.items?.length || consumerGroups?.items?.length < 1) &&
-      search.length < 1
-    ) {
-      return (
-        <EmptyState
-          emptyStateProps={{
-            variant: MASEmptyStateVariant.NoConsumerGroups,
-          }}
-          titleProps={{
-            title: t('consumerGroup.empty_consumer_title'),
-          }}
-          emptyStateBodyProps={{
-            body: t('consumerGroup.empty_consumer_body'),
-          }}
-        />
-      );
-    } else if (consumerGroups) {
-      return (
-        <ConsumerGroupsTable
-          consumerGroups={
-            search
-              ? consumerGroups?.items?.slice(0, perPage)
-              : consumerGroups?.items?.slice(
-                  consumerGroups?.items.length > 1 ? offset : 0,
-                  offset + perPage
-                )
-          }
-          total={consumerGroups?.items?.length || 0}
-          page={page}
-          perPage={perPage}
-          search={search}
-          setSearch={setSearch}
-          rowDataTestId={rowDataTestId}
-          onViewConsumerGroup={onViewConsumerGroup}
-          isDrawerOpen={isExpanded}
-          refreshConsumerGroups={fetchConsumerGroups}
-          onSort={onSort}
-          sortBy={sortBy}
-        />
-      );
+  const RenderTable = () => {
+    switch (true) {
+      case consumerGroups === undefined:
+        return (
+          <PageSection
+            className='kafka-ui-m-full-height'
+            variant={PageSectionVariants.light}
+            padding={{ default: 'noPadding' }}
+          >
+            <MASLoading />
+          </PageSection>
+        );
+      case (!consumerGroups?.items?.length ||
+        consumerGroups?.items?.length < 1) &&
+        search.length < 1:
+        return (
+          <EmptyState
+            emptyStateProps={{
+              variant: MASEmptyStateVariant.NoConsumerGroups,
+            }}
+            titleProps={{
+              title: t('consumerGroup.empty_consumer_title'),
+            }}
+            emptyStateBodyProps={{
+              body: t('consumerGroup.empty_consumer_body'),
+            }}
+          />
+        );
+      case consumerGroups?.items !== undefined:
+        return (
+          <ConsumerGroupsTable
+            consumerGroups={consumerGroups?.items}
+            total={consumerGroups?.total || 0}
+            page={page}
+            perPage={perPage}
+            search={search}
+            setSearch={onSearch}
+            rowDataTestId={rowDataTestId}
+            onViewConsumerGroup={onViewConsumerGroup}
+            isDrawerOpen={isExpanded}
+            refreshConsumerGroups={fetchConsumerGroups}
+            onSort={onSort}
+            sortBy={sortBy}
+          />
+        );
+      default:
+        return <></>;
     }
-    return <></>;
   };
 
   return (
@@ -190,7 +183,7 @@ const ConsumerGroups: React.FunctionComponent<ConsumerGroupsProps> = ({
         refreshConsumerGroups={fetchConsumerGroups}
         consumerGroupDetail={consumerGroupDetail}
       >
-        {renderConsumerTable()}
+        <RenderTable />
       </MASDrawer>
     </Suspense>
   );

--- a/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupDetail/ConsumerGroupDetail.tsx
@@ -150,7 +150,7 @@ const ConsumerGroupDetail: React.FunctionComponent<
             </Text>
             <Text component={TextVariants.p}>
               <Text component={TextVariants.h2}>
-                {ConsumerGroupState(consumerGroupDetail?.state)}
+                <ConsumerGroupState state={consumerGroupDetail?.state} />
               </Text>
             </Text>
           </FlexItem>

--- a/src/modules/ConsumerGroups/components/ConsumerGroupState.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupState.tsx
@@ -1,25 +1,25 @@
+import { VFC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConsumerGroupState as ConsumerGroupStateEnum } from '@rhoas/kafka-instance-sdk';
 
-export const ConsumerGroupState = (
-  state: ConsumerGroupStateEnum | undefined
-) => {
+export const ConsumerGroupState: VFC<{
+  state: ConsumerGroupStateEnum | undefined;
+}> = ({ state }) => {
   const { t } = useTranslation(['kafkaTemporaryFixMe']);
-
   switch (state) {
     case ConsumerGroupStateEnum.Stable:
-      return t('consumerGroup.state.stable');
+      return <>{t('consumerGroup.state.stable')}</>;
     case ConsumerGroupStateEnum.Empty:
-      return t('consumerGroup.state.empty');
+      return <>{t('consumerGroup.state.empty')}</>;
     case ConsumerGroupStateEnum.Dead:
-      return t('consumerGroup.state.dead');
+      return <>{t('consumerGroup.state.dead')}</>;
     case ConsumerGroupStateEnum.CompletingRebalance:
-      return t('consumerGroup.state.completing_rebalance');
+      return <>{t('consumerGroup.state.completing_rebalance')}</>;
     case ConsumerGroupStateEnum.PreparingRebalance:
-      return t('consumerGroup.state.preparing_rebalance');
+      return <>{t('consumerGroup.state.preparing_rebalance')}</>;
     case ConsumerGroupStateEnum.Unknown:
-      return t('consumerGroup.state.unknown');
+      return <>{t('consumerGroup.state.unknown')}</>;
     default:
-      return null;
+      return <></>;
   }
 };

--- a/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupToolbar.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupToolbar.tsx
@@ -18,103 +18,99 @@ export type ConsumerGroupToolbarProps = {
   perPage: number;
 };
 
-const ConsumerGroupToolbar: React.FC<ConsumerGroupToolbarProps> = ({
-  search,
-  setSearch,
-  total,
-  page,
-  perPage,
-}) => {
-  const { t } = useTranslation(['kafkaTemporaryFixMe']);
-  const [searchInputValue, setSearchInputValue] = useState<string>('');
+const ConsumerGroupToolbar: React.FC<ConsumerGroupToolbarProps> = React.memo(
+  ({ search, setSearch, total, page, perPage }) => {
+    const { t } = useTranslation(['kafkaTemporaryFixMe']);
+    const [searchInputValue, setSearchInputValue] = useState<string>('');
 
-  const onClear = () => {
-    setSearch('');
-  };
+    const onClear = () => {
+      setSearch('');
+    };
 
-  const onChangeInput = (value: string) => {
-    setSearchInputValue(value);
-  };
+    const onChangeInput = (value: string) => {
+      setSearchInputValue(value);
+    };
 
-  const onSearch = () => {
-    setSearch(searchInputValue);
-    setSearchInputValue('');
-  };
+    const onSearch = () => {
+      setSearch(searchInputValue);
+      setSearchInputValue('');
+    };
 
-  const onDeleteChip = () => {
-    setSearch('');
-  };
+    const onDeleteChip = () => {
+      setSearch('');
+    };
 
-  const toggleGroupItems = (
-    <>
-      <ToolbarFilter
-        chips={search ? [search] : []}
-        deleteChip={onDeleteChip}
-        categoryName={''}
-      >
-        <InputGroup>
-          <TextInput
-            name='searchConsumerGroups'
-            id='search-consumer-groups-input'
-            type='search'
-            aria-label={t('consumerGroup.consumer_group_search_input')}
-            placeholder={t('common.search')}
-            value={searchInputValue}
-            onChange={onChangeInput}
+    const toggleGroupItems = (
+      <>
+        <ToolbarFilter
+          chips={search ? [search] : []}
+          deleteChip={onDeleteChip}
+          categoryName={''}
+        >
+          <InputGroup>
+            <TextInput
+              name='searchConsumerGroups'
+              id='search-consumer-groups-input'
+              type='search'
+              aria-label={t('consumerGroup.consumer_group_search_input')}
+              placeholder={t('common.search')}
+              value={searchInputValue}
+              onChange={onChangeInput}
+            />
+            <Button
+              variant={ButtonVariant.control}
+              isDisabled={searchInputValue.length ? false : true}
+              onClick={onSearch}
+              aria-label={t('consumerGroup.consumer_group_search')}
+            >
+              <SearchIcon />
+            </Button>
+          </InputGroup>
+        </ToolbarFilter>
+      </>
+    );
+
+    const toolbarItems: ToolbarItemProps[] = [];
+
+    if (total > 0) {
+      toolbarItems.push({
+        item: (
+          <MASPagination
+            widgetId='consumer-group-pagination-options-menu-top'
+            itemCount={total}
+            page={page}
+            perPage={perPage}
+            titles={{
+              paginationTitle: t('common.minimal_pagination'),
+              perPageSuffix: t('common.per_page_suffix'),
+              toFirstPage: t('common.to_first_page'),
+              toPreviousPage: t('common.to_previous_page'),
+              toLastPage: t('common.to_last_page'),
+              toNextPage: t('common.to_next_page'),
+              optionsToggle: t('common.options_toggle'),
+              currPage: t('common.curr_page'),
+            }}
           />
-          <Button
-            variant={ButtonVariant.control}
-            isDisabled={searchInputValue.length ? false : true}
-            onClick={onSearch}
-            aria-label={t('consumerGroup.consumer_group_search')}
-          >
-            <SearchIcon />
-          </Button>
-        </InputGroup>
-      </ToolbarFilter>
-    </>
-  );
+        ),
+        variant: 'pagination',
+        alignment: { default: 'alignRight' },
+      });
+    }
 
-  const toolbarItems: ToolbarItemProps[] = [];
-
-  if (total && total > 0) {
-    toolbarItems.push({
-      item: (
-        <MASPagination
-          widgetId='consumer-group-pagination-options-menu-top'
-          itemCount={total}
-          page={page}
-          perPage={perPage}
-          titles={{
-            paginationTitle: t('common.minimal_pagination'),
-            perPageSuffix: t('common.per_page_suffix'),
-            toFirstPage: t('common.to_first_page'),
-            toPreviousPage: t('common.to_previous_page'),
-            toLastPage: t('common.to_last_page'),
-            toNextPage: t('common.to_next_page'),
-            optionsToggle: t('common.options_toggle'),
-            currPage: t('common.curr_page'),
-          }}
-        />
-      ),
-      variant: 'pagination',
-      alignment: { default: 'alignRight' },
-    });
+    return (
+      <MASToolbar
+        toolbarProps={{
+          id: 'instance-toolbar',
+          clearAllFilters: onClear,
+          collapseListedFiltersBreakpoint: 'md',
+          inset: { xl: 'insetLg' },
+        }}
+        toggleGroupProps={{ toggleIcon: '', breakpoint: 'md' }}
+        toggleGroupItems={toggleGroupItems}
+        toolbarItems={toolbarItems}
+      />
+    );
   }
-
-  return (
-    <MASToolbar
-      toolbarProps={{
-        id: 'instance-toolbar',
-        clearAllFilters: onClear,
-        collapseListedFiltersBreakpoint: 'md',
-        inset: { xl: 'insetLg' },
-      }}
-      toggleGroupProps={{ toggleIcon: '', breakpoint: 'md' }}
-      toggleGroupItems={toggleGroupItems}
-      toolbarItems={toolbarItems}
-    />
-  );
-};
+);
 
 export { ConsumerGroupToolbar };

--- a/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
@@ -95,7 +95,7 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
           groupId,
           metrics.activeConsumers,
           metrics.laggingPartitions,
-          ConsumerGroupState(state),
+          { title: <ConsumerGroupState state={state} /> },
         ],
         originalData: { ...row, rowId: groupId },
       });

--- a/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
+++ b/src/modules/ConsumerGroups/components/ConsumerGroupsTable/ConsumerGroupsTable.tsx
@@ -29,7 +29,6 @@ import {
   useModal,
 } from '@rhoas/app-services-ui-shared';
 import { ConsumerGroupState } from '../ConsumerGroupState';
-// import { ConsumerGroupState } from '@rhoas/kafka-instance-sdk';
 
 export type ConsumerGroupsTableProps = ConsumerGroupToolbarProps & {
   consumerGroups?: ConsumerGroup[];
@@ -192,6 +191,8 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
     }
   };
 
+  const rows = preparedTableCells();
+
   return (
     <>
       <ConsumerGroupToolbar
@@ -204,9 +205,9 @@ const ConsumerGroupsTable: React.FC<ConsumerGroupsTableProps> = ({
       <MASTable
         tableProps={{
           cells: tableColumns,
-          rows: preparedTableCells(),
+          rows,
           'aria-label': t('consumerGroup.consumer_group_list'),
-          actionResolver: actionResolver,
+          actionResolver,
           shouldDefaultCustomRowWrapper: true,
           variant: TableVariant.compact,
           onSort,

--- a/src/modules/Topics/pages/TopicDetail/TopicDetailFederated.tsx
+++ b/src/modules/Topics/pages/TopicDetail/TopicDetailFederated.tsx
@@ -6,7 +6,7 @@ import {
   FederatedProps,
   IConfiguration,
 } from '@app/contexts';
-import { KafkaModalLoader } from '@app/components/KafkaModal';
+import { KafkaModalLoader, PaginationProvider } from '@app/components';
 import { ModalProvider } from '@rhoas/app-services-ui-components';
 
 export type TopicDetailFederatedProps = FederatedProps &
@@ -37,7 +37,9 @@ const TopicDetailFederated: FunctionComponent<TopicDetailFederatedProps> = ({
         }}
       >
         <ModalProvider>
-          <TopicDetailPage />
+          <PaginationProvider>
+            <TopicDetailPage />
+          </PaginationProvider>
           <KafkaModalLoader />
         </ModalProvider>
       </FederatedContext.Provider>

--- a/src/modules/Topics/pages/UpdateTopic/UpdateTopicFederated.tsx
+++ b/src/modules/Topics/pages/UpdateTopic/UpdateTopicFederated.tsx
@@ -6,7 +6,7 @@ import {
   FederatedProps,
   IConfiguration,
 } from '@app/contexts';
-import { KafkaModalLoader } from '@app/components/KafkaModal';
+import { KafkaModalLoader, PaginationProvider } from '@app/components';
 import { ModalProvider } from '@rhoas/app-services-ui-components';
 
 export type UpdateTopicFederatedProps = FederatedProps &
@@ -35,7 +35,9 @@ const UpdateTopicFederated: FunctionComponent<UpdateTopicFederatedProps> = ({
         }}
       >
         <ModalProvider>
-          <UpdateTopicPage />
+          <PaginationProvider>
+            <UpdateTopicPage />
+          </PaginationProvider>
           <KafkaModalLoader />
         </ModalProvider>
       </FederatedContext.Provider>

--- a/src/services/consumer-groups.ts
+++ b/src/services/consumer-groups.ts
@@ -12,8 +12,6 @@ import { SortByDirection } from '@patternfly/react-table';
 
 const getConsumerGroups = async (
   config: IConfiguration | undefined,
-  offset?: number,
-  limit?: number,
   size?: number,
   page?: number,
   topic?: string,
@@ -31,8 +29,8 @@ const getConsumerGroups = async (
   );
   const response: AxiosResponse<ConsumerGroupList> =
     await api.getConsumerGroups(
-      offset,
-      limit,
+      undefined,
+      undefined,
       size,
       page,
       topic,


### PR DESCRIPTION
Fixed below bugs
1. Fix consumer groups pagination issue and breaking page issue
2. Fix Consumer groups for topic pagination issue 
3. Fix consumer groups pagination issue on topic details page 
4.  Fix consumer groups pagination issue on topic edit page 
5. Fix searching issue in consumers groups page on second page due to page number in payload 
6. Fix searching issue in topics page on second page due to page number in payload  
7. Fix consumer groups API issue